### PR TITLE
Build Docker image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,52 @@
+name: Docker
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - 'v**'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        flavor: |
+          latest=true
+        tags: |
+          type=semver,pattern={{version}}
+          type=ref,event=branch
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+
+ARG BUILD_OS=linux \
+    BUILD_ARCH=x64 \
+    DOTNET_VERSION=6.0
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} as build-env
+
+WORKDIR /src
+COPY . .
+
+ENV PUBLISH_PROFILE="FrameworkDependant__${BUILD_OS}_${BUILD_ARCH}"
+
+RUN dotnet publish Nestor80.sln /p:PublishProfile=${PUBLISH_PROFILE} /p:DebugType=None -c Release
+
+# ----
+
+# Cannot use alpine since uses musl instead of linux-c.
+FROM mcr.microsoft.com/dotnet/runtime:${DOTNET_VERSION}-bullseye-slim
+
+COPY --from=build-env /src/N80/bin/Release/net6.0/publish/* /bin
+
+ENTRYPOINT ["/bin/N80"]


### PR DESCRIPTION
* Added Dockerfile that builds from source code.
* Allows args to build different arch, based on Publish profile.
* Added GitHub Actions Workflow to build on each commit to `master` and `git tag`.

Expected image would be `ghcr.io/konamiman/nestor80` .
This can later be used to assemble code on other repos.