### PR TITLE
Fix dummy duplicates of public symbols being created inside modules

### DIFF
--- a/Assembler/AssemblySourceProcessor.PseudoOps.cs
+++ b/Assembler/AssemblySourceProcessor.PseudoOps.cs
@@ -644,6 +644,7 @@ namespace Konamiman.Nestor80.Assembler
             var symbolNames = new List<string>();
             while(!walker.AtEndOfLine) {
                 var symbolName = walker.ExtractExpression();
+                symbolName = state.Modularize(symbolName);
                 if(string.IsNullOrWhiteSpace(symbolName)) {
                     AddError(AssemblyErrorCode.InvalidArgument, $"{opcode.ToUpper()}: the symbol name can't be empty");
                     continue;


### PR DESCRIPTION
Example code:

```
module FOO
BAR equ 34
public BAR
endmod
```

This was creating two public symbols: `FOO.BAR` with value 34 (correct) and `BAR` with value 0 (incorrect). This pull request fixes this so only the single correct symbols is created.