### PR TITLE
Fix exception that should be an error message

### DIFF
--- a/Assembler/AssemblySourceProcessor.CpuInstructions.cs
+++ b/Assembler/AssemblySourceProcessor.CpuInstructions.cs
@@ -174,10 +174,16 @@ namespace Konamiman.Nestor80.Assembler
                 return line;
             }
 
-            // There's at least one variable argument.
+            // There's (or there should be) at least one variable argument.
 
             var firstArgumentType = GetCpuInstructionArgumentPattern(firstArgument);
             var secondArgumentType = GetCpuInstructionArgumentPattern(secondArgument);
+
+            if(firstArgumentType is CpuParsedArgType.Fixed && secondArgumentType is CpuParsedArgType.Fixed or CpuParsedArgType.None) {
+                AddError(AssemblyErrorCode.InvalidCpuInstruction, $"Invalid {currentCpu} instruction: {instructionSearchKey}");
+                walker.DiscardRemaining();
+                return new CpuInstructionLine() { IsInvalid = true };
+            }
 
             bool isInstructionWithTwoVariableArguments = false;
             var isLD = string.Equals("LD", opcode, StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
When combining an existing instruction mnemonic with one or two existing register names, but the combination wasn't a valid instruction (for example `sbc bc`), a "ProcessCpuInstruction: something went wrong: a fixed instruction argument was not processed as such" exception was thrown. Now a regular "invalid instruction" error is generated instead.