### PR TITLE
Remove v1.2 preview level, change (c) text

### DIFF
--- a/N80/Program.Help.cs
+++ b/N80/Program.Help.cs
@@ -5,8 +5,8 @@ namespace Konamiman.Nestor80.N80
     internal partial class Program
     {
         static readonly string bannerText = """
-            Nestor80 - The Z80 assembler for the 21th century
-            (c) Konamiman 2023
+            Nestor80 - The Z80 and Z280 assembler for the 21th century
+            (c) Konamiman 2024
 
             """;
 

--- a/N80/Program.cs
+++ b/N80/Program.cs
@@ -25,7 +25,7 @@ namespace Konamiman.Nestor80.N80
     /// </summary>
     internal partial class Program
     {
-        const int PREVIEW_LEVEL = 1;
+        const int PREVIEW_LEVEL = 0;
 
         const int ERR_SUCCESS = 0;
         const int ERR_BAD_ARGUMENTS = 1;


### PR DESCRIPTION
- Set `PREVIEW_LEVEL` to 0 so the N80 version is simply 1.2
- Change the N80 help text to mention the Z280 and change the (c) year to 2024