### PR TITLE
Fix macro definitions without arguments

### DIFF
--- a/Assembler/AssemblySourceProcessor.cs
+++ b/Assembler/AssemblySourceProcessor.cs
@@ -613,7 +613,7 @@ namespace Konamiman.Nestor80.Assembler
             //
             // TITLE EQU 1      ---> defines constant "TITLE" with value 1
             // FOO: TITLE EQU 1 ---> sets the program title as "EQU 1"
-            if(!definingMacro && !state.InFalseConditional && !walker.AtEndOfLine) {
+            if(!definingMacro && !state.InFalseConditional && (!walker.AtEndOfLine || symbol.Equals("MACRO", StringComparison.OrdinalIgnoreCase))) {
                 if(label is not null && constantDefinitionOpcodes.Contains(symbol, StringComparer.OrdinalIgnoreCase)) {
                     opcode = symbol;
                     processedLine = ProcessConstantDefinition(opcode: opcode, name: label.TrimEnd(':'), walker: walker);


### PR DESCRIPTION
This pull request fixes a bug that made it impossible to define a macro without arguments if the macro name was specified with an ending colon, for example:

```
FOO: MACRO
ENDM
```

This would throw an _"Unknown instruction: MACRO"_ error. If the macro had arguments or if the macro name didn't have a colon at the end then it would work fine.