### PR TITLE
Fix: expression evaluation being unnecessarily deferred when constant symbols are used

### DIFF
--- a/Assembler/AssemblySourceProcessor.cs
+++ b/Assembler/AssemblySourceProcessor.cs
@@ -1025,7 +1025,7 @@ namespace Konamiman.Nestor80.Assembler
                         AddError(AssemblyErrorCode.DuplicatedSymbol, $"Duplicate label: {labelValue}");
                     }
                     else {
-                        AddError(AssemblyErrorCode.DifferentPassValues, $"Label {labelValue} has different values in pass 1 ({symbol.Value:X4}h) and in pass 2 ({state.GetCurrentLocation().Value:X4}h)");
+                        AddError(AssemblyErrorCode.DifferentPassValues, $"Label {labelValue} has different values in pass 1 ({symbol.Value:X4}h) and in pass 2 ({state.GetCurrentLocation():X4}h)");
                     }
                 }
 

--- a/Assembler/Expressions/Expression.Evaluation.cs
+++ b/Assembler/Expressions/Expression.Evaluation.cs
@@ -190,7 +190,7 @@ namespace Konamiman.Nestor80.Assembler
             }
 
             if(stopOnSymbolFound) {
-                var symbolParts = Parts.OfType<SymbolReference>();
+                var symbolParts = Parts.OfType<SymbolReference>().Where(s => !GetSymbol(s.SymbolName, s.IsExternal, s.IsRoot).IsConstant);
                 if(symbolParts.Any()) {
                     //We need each symbol to be registered, even if value is still unknown
                     foreach(var sr in symbolParts) {


### PR DESCRIPTION
Nestor80 defers the evaluation of expressions containing potentially unknown symbols (relocatable labels not yet defined and external symbols) to pass 2. However it was mistakenly also deferring the evaluation of expressions containing only constant symbols (defined with `EQU` or `DEFL`). This caused underisable effects, for example the following code

```
address: equ 1000h

    org address

start: ret

```

was throwing an error: _"Label start has different values in pass 1 (ASEG 0000h) and in pass 2 (ASEG 1000h)"_.

This pull request fixes that by immediately evaluating expressions that only contain numeric literals and constant symbols.