### PR TITLE
Fix for instructions with a "(reg+expression)" argument and parenthesis in the expression

### DIFF
--- a/Assembler/AssemblySourceProcessor.CpuInstructions.cs
+++ b/Assembler/AssemblySourceProcessor.CpuInstructions.cs
@@ -11,13 +11,13 @@ namespace Konamiman.Nestor80.Assembler
 
     public partial class AssemblySourceProcessor
     {
-        private static readonly Regex ixPlusArgumentRegex = new(@"^\(\s*IX\s*[+-][^)]+\)$", RegxOp);
-        private static readonly Regex iyPlusArgumentRegex = new(@"^\(\s*IY\s*[+-][^)]+\)$", RegxOp);
-        private static readonly Regex pcPlusArgumentRegex = new(@"^\(\s*PC\s*[+-][^)]+\)$", RegxOp);
-        private static readonly Regex spPlusArgumentRegex = new(@"^\(\s*SP\s*[+-][^)]+\)$", RegxOp);
-        private static readonly Regex hlPlusArgumentRegex = new(@"^\(\s*HL\s*[+-][^)]+\)$", RegxOp);
-        private static readonly Regex indexPlusArgumentRegex = new(@"^\(\s*I(X|Y)\s*(?<sign>[+-])(?<expression>[^)]+)\)$", RegxOp);
-        private static readonly Regex registerPlusArgumentRegex = new(@"^\(\s*(IX|IY|PC|SP|HL)\s*(?<sign>[+-])(?<expression>[^)]+)\)$", RegxOp);
+        private static readonly Regex ixPlusArgumentRegex = new(@"^\(\s*IX\s*[+-].+\)$", RegxOp);
+        private static readonly Regex iyPlusArgumentRegex = new(@"^\(\s*IY\s*[+-].+\)$", RegxOp);
+        private static readonly Regex pcPlusArgumentRegex = new(@"^\(\s*PC\s*[+-].+\)$", RegxOp);
+        private static readonly Regex spPlusArgumentRegex = new(@"^\(\s*SP\s*[+-].+\)$", RegxOp);
+        private static readonly Regex hlPlusArgumentRegex = new(@"^\(\s*HL\s*[+-].+\)$", RegxOp);
+        private static readonly Regex indexPlusArgumentRegex = new(@"^\(\s*I(X|Y)\s*(?<sign>[+-])(?<expression>.+)\)$", RegxOp);
+        private static readonly Regex registerPlusArgumentRegex = new(@"^\(\s*(IX|IY|PC|SP|HL)\s*(?<sign>[+-])(?<expression>.+)\)$", RegxOp);
         private static readonly Regex z80MemPointedByRegisterRegex = new(@"^\(\s*(?<reg>HL|DE|BC|IX|IY|SP|C)\s*\)$", RegxOp);
         private static readonly Regex z280MemPointedByRegisterRegex = new(@"^\(\s*(?<reg>HL|DE|BC|IX|IY|PC|SP|C|IX *\+ *IY|HL *\+ *IX|HL *\+ *IY)\s*\)$", RegxOp);
         private static readonly Regex registerRegex = new(@"^[A-Z]{1,3}$", RegxOp);


### PR DESCRIPTION
Instructions with a `(reg+expression)` argument were throwing an error when the expression had itself parenthesis. This was due to an error in the regular expressions used to parse the source code.

The fix can be tested with the following code:

```
    ld a,(ix+(1))
    ld a,(ix+1)    
    
    set 0,(iy+(1))
    set 0,(iy+1)
    
    .cpu Z280

    ld a,(sp+(1))
    ld a,(sp+1)

    ld a,(pc+(1))
    ld a,(pc+1)

    ld a,(hl+(1))
    ld a,(hl+1)
```

Without this fix the instructions with `+(1)` will fail with "invalid argument" or "constant not found" errors, with the fix these will assemble as expected:

```
  0000'   DD 7E 01                  ld a,(ix+(1))
  0003'   DD 7E 01                  ld a,(ix+1)    
                                
  0006'   FD CB 01 C6               set 0,(iy+(1))
  000A'   FD CB 01 C6               set 0,(iy+1)
                                
                                    .cpu Z280
                                
  000E'   DD 78 01 00               ld a,(sp+(1))
  0012'   DD 78 01 00               ld a,(sp+1)
                                
  0016'   FD 78 01 00               ld a,(pc+(1))
  001A'   FD 78 01 00               ld a,(pc+1)
                                
  001E'   FD 7B 01 00               ld a,(hl+(1))
  0022'   FD 7B 01 00               ld a,(hl+1)
```