### PR TITLE
Add missing "Modularize" call in AssemblySourceProcessor.GetLinkItemsGroupFromExpression

### DIFF
--- a/Assembler/AssemblySourceProcessor.cs
+++ b/Assembler/AssemblySourceProcessor.cs
@@ -914,7 +914,7 @@ namespace Konamiman.Nestor80.Assembler
                     items.Add(LinkItem.ForAddressReference(ad.Type, ad.Value));
                 }
                 else if(part is SymbolReference sr) {
-                    var symbol = state.GetSymbolWithoutLocalNameReplacement(sr.SymbolName);
+                    var symbol = state.GetSymbolWithoutLocalNameReplacement(state.Modularize(sr.SymbolName));
                     if(symbol is null) {
                         throw new InvalidOperationException($"{nameof(GetLinkItemsGroupFromExpression)}: {symbol} doesn't exist (this should have been catched earlier)");
                     }


### PR DESCRIPTION
This was causing an exception when an expression involving a relocatable symbol inside a module had to be converted to a link items group. Example code:

```
  cseg

  module FOOBAR

  ld hl,THING+1
  ret
THING:

  endmod
```

Without the fix this code causes an exception: `Unexpected error: (InvalidOperationException) GetLinkItemsGroupFromExpression:  doesn't exist (this should have been catched earlier)`