### PR TITLE
Make ProgramName mandatory in the input fot OutputGenerator.GenerateRelocatable

### DIFF
--- a/Assembler/OutputGenerator.cs
+++ b/Assembler/OutputGenerator.cs
@@ -161,7 +161,7 @@ namespace Konamiman.Nestor80.Assembler
         static string currentCommonBlockName;
 
         /// <summary>
-        /// Generate a LINK-80 compatible relative file from an <see cref="AssemblyResult"/>.
+        /// Generate a LINK-80 compatible relocatable file from an <see cref="AssemblyResult"/>.
         /// </summary>
         /// <param name="assemblyResult">Assembly result ro use for the file generation.</param>
         /// <param name="outputStream">The stream to write the result to.</param>
@@ -185,6 +185,10 @@ namespace Konamiman.Nestor80.Assembler
                 { AddressType.ASEG, 0 },
                 { AddressType.COMMON, 0 }
             };
+
+            if(assemblyResult.ProgramName is null) {
+                throw new InvalidOperationException($"{nameof(assemblyResult)}.{nameof(assemblyResult.ProgramName)} is mandatory when generating a relocatable file.");
+            }
 
             var publicSymbols = assemblyResult.Symbols
                 .Where(s => s.IsPublic)
@@ -661,6 +665,9 @@ namespace Konamiman.Nestor80.Assembler
             outputLines.Add($"H {assemblyResult.SdccAreas.Length:X} areas {totalSymbolsCount:X} global symbols");
 
             if(!assemblyResult.ImplicitProgramName) {
+                if(assemblyResult.ProgramName is null) {
+                    throw new InvalidOperationException($"{nameof(assemblyResult)}.{nameof(assemblyResult.ProgramName)} is mandatory when generating a SDCC compatible relocatable file if {nameof(assemblyResult)}.{nameof(assemblyResult.ImplicitProgramName)} is false.");
+                }
                 outputLines.Add($"M {assemblyResult.ProgramName}");
             }
 


### PR DESCRIPTION
If `ProgramName` in the instance of `AssemblyResult` passed to `OutputGenerator.GenerateRelocatable` is not set a null reference error will be throw later in the process, so check if the value is set and throw an explanatory error if not.

Note that this could happen only when using Nestor80 programmatically (via the `Assembler.dll` library file), since the `N80` binary always sets `ProgramName` appropriately.