### PR TITLE
Add support for aligning code

### DIFF
--- a/Assembler/AssemblySourceProcessor.PseudoOps.cs
+++ b/Assembler/AssemblySourceProcessor.PseudoOps.cs
@@ -30,6 +30,9 @@ namespace Konamiman.Nestor80.Assembler
             // .8080: Unsupported, always throws error
             { ".8080", ProcessChangeCpuTo8080Line },
 
+            // .ALIGN: Align code to an address multiple of a given value
+            { ".ALIGN", ProcessAlignLine },
+
             // .AREA: Alias for AREA
             { ".AREA", ProcessSdccAreaLine },
 
@@ -117,9 +120,6 @@ namespace Konamiman.Nestor80.Assembler
             
             // .Z80: Select Z80 as the current CPU
             { ".Z80", ProcessChangeCpuToZ80Line },
-
-            // ALIGN: Align code to an address multiple of a given value
-            { "ALIGN", ProcessAlignLine },
 
             // AREA: Change current SDCC area
             { "AREA", ProcessSdccAreaLine },

--- a/Assembler/AssemblySourceProcessor.PseudoOps.cs
+++ b/Assembler/AssemblySourceProcessor.PseudoOps.cs
@@ -2065,7 +2065,7 @@ namespace Konamiman.Nestor80.Assembler
                 SetBuildType(BuildType.Absolute);
             }
             else if(buildType is not BuildType.Absolute) {
-                AddError(AssemblyErrorCode.IgnoredForAbsoluteOutput, $"{opcode.ToUpper()} can only be used when the build type is absolute");
+                AddError(AssemblyErrorCode.IgnoredForAbsoluteOutput, $"{opcode.ToUpper()} can only be used when the build type is absolute, address alignments for relocatable programs are controlled with the --align-code and --align-data arguments of Linkstor80");
                 walker.DiscardRemaining();
                 return line;
             }

--- a/Assembler/AssemblySourceProcessor.PseudoOps.cs
+++ b/Assembler/AssemblySourceProcessor.PseudoOps.cs
@@ -118,6 +118,9 @@ namespace Konamiman.Nestor80.Assembler
             // .Z80: Select Z80 as the current CPU
             { ".Z80", ProcessChangeCpuToZ80Line },
 
+            // ALIGN: Align code to an address multiple of a given value
+            { "ALIGN", ProcessAlignLine },
+
             // AREA: Change current SDCC area
             { "AREA", ProcessSdccAreaLine },
 
@@ -2052,6 +2055,81 @@ namespace Konamiman.Nestor80.Assembler
         {
             state.RelativeLabelsEnabled = false;
             return new RelabLine() { Enable = false };
+        }
+
+        static ProcessedSourceLine ProcessAlignLine(string opcode, SourceLineWalker walker)
+        {
+            var line = new AlignLine();
+
+            if(buildType == BuildType.Automatic) {
+                SetBuildType(BuildType.Absolute);
+            }
+            else if(buildType is not BuildType.Absolute) {
+                AddError(AssemblyErrorCode.IgnoredForAbsoluteOutput, $"{opcode.ToUpper()} can only be used when the build type is absolute");
+                walker.DiscardRemaining();
+                return line;
+            }
+
+            Address fillValue = null;
+            Address alignValue;
+            if(walker.AtEndOfLine) {
+                AddError(AssemblyErrorCode.MissingValue, $"{opcode.ToUpper()} needs the alignment value argument");
+                return line;
+            }
+            else try {
+                    var alignValueExpressionText = walker.ExtractExpression();
+                    var alignValueExpression = state.GetExpressionFor(alignValueExpressionText);
+                    alignValue = alignValueExpression.Evaluate();
+                    if(!alignValue.IsAbsolute) {
+                        AddError(AssemblyErrorCode.InvalidArgument, $"{opcode.ToUpper()}: the alignment value argument must evaluate to an absolute value");
+                        walker.DiscardRemaining();
+                        return line;
+                    }
+                    else if(alignValue.Value < 1 || alignValue.Value > 65535) {
+                        AddError(AssemblyErrorCode.InvalidArgument, $"{opcode.ToUpper()}: the alignment value argument must be between 1 and 65535");
+                        walker.DiscardRemaining();
+                        return line;
+                    }
+
+                    if(!walker.AtEndOfLine) {
+                        var fillValueExpressionText = walker.ExtractExpression();
+                        var fillValueExpression = state.GetExpressionFor(fillValueExpressionText, isByte: true);
+                        fillValue = EvaluateIfNoSymbolsOrPass2(fillValueExpression);
+                        if(fillValue is null) {
+                            state.RegisterPendingExpression(line, fillValueExpression, argumentType: CpuInstrArgType.Byte);
+                        }
+                        else if(!fillValue.IsValidByte) {
+                            AddError(AssemblyErrorCode.InvalidArgument, $"{opcode.ToUpper()}: the value argument must evaluate to a valid byte");
+                            walker.DiscardRemaining();
+                            return line;
+                        }
+                    }
+                }
+                catch(InvalidExpressionException ex) {
+                    AddError(ex.ErrorCode, $"Invalid expression for {opcode.ToUpper()}: {ex.Message}");
+                    walker.DiscardRemaining();
+                    return line;
+                }
+
+            int newLocationPointer = state.CurrentLocationPointer + alignValue.Value - 1;
+            newLocationPointer = newLocationPointer - (newLocationPointer % alignValue.Value);
+            if(newLocationPointer > ushort.MaxValue) {
+                AddError(AssemblyErrorCode.InvalidExpression, $"{opcode.ToUpper()}: the alignment value {alignValue.Value} is too large, it would cause the location pointer to exceed 65535");
+                return new AlignLine();
+            }
+
+            var increment = (ushort)(newLocationPointer - state.CurrentLocationPointer);
+            state.SwitchToLocation((ushort)newLocationPointer);
+
+            line.NewLocationArea = state.CurrentLocationArea;
+            line.NewLocationCounter = state.CurrentLocationPointer;
+            line.DeclaredAlignmentValue = alignValue.Value;
+            line.Size = increment;
+            if(fillValue is not null) {
+                line.Value = fillValue.ValueAsByte;
+            };
+
+            return line;
         }
 
         static ProcessedSourceLine ProcessSdccAreaLine(string opcode, SourceLineWalker walker)

--- a/Assembler/AssemblySourceProcessor.cs
+++ b/Assembler/AssemblySourceProcessor.cs
@@ -746,10 +746,10 @@ namespace Konamiman.Nestor80.Assembler
                 else if(processedLine is ChangeAreaLine cal) {
                     SetBuildType(BuildType.Relocatable);
                 }
-                else if(processedLine is ChangeOriginLine col) {
+                else if(processedLine is ChangeOriginLine or AlignLine) {
                     SetBuildType(BuildType.Absolute);
                     state.SwitchToArea(AddressType.ASEG);
-                    state.SwitchToLocation(col.NewLocationCounter);
+                    state.SwitchToLocation(((IChangesLocationCounter)processedLine).NewLocationCounter);
                 }
                 else if(processedLine is IProducesOutput or DefineSpaceLine or LinkerFileReadRequestLine) {
                     SetBuildType(BuildType.Relocatable);

--- a/Assembler/OutputGenerator.cs
+++ b/Assembler/OutputGenerator.cs
@@ -84,7 +84,7 @@ namespace Konamiman.Nestor80.Assembler
                         lastAddressPlusOne = 65536;
                     }
                 }
-                else if(line is DefineSpaceLine ds) {
+                else if(line is DefineSpaceLine ds) { //Note that this includes AlignLine too
                     var outputByte = ds.Value ?? 0;
                     var length = ds.Size;
                     if(directFileWrite) {

--- a/Assembler/ProcessedLineTypes/AlignLine.cs
+++ b/Assembler/ProcessedLineTypes/AlignLine.cs
@@ -1,0 +1,11 @@
+﻿namespace Konamiman.Nestor80.Assembler.Output
+{
+    // An alignment works effectively as a define space line, so we recycle the DefineSpaceLine class
+    // repurposing the "Size" property to hold the actual calculated address alignment value.
+    public class AlignLine : DefineSpaceLine
+    {
+        public ushort DeclaredAlignmentValue { get; set; }
+
+        public override string ToString() => $"{base.ToString()}, {DeclaredAlignmentValue} (actual: {Size}), {Value}";
+    }
+}

--- a/LK80/Program.Help.cs
+++ b/LK80/Program.Help.cs
@@ -6,7 +6,7 @@ internal partial class Program
 {
     static readonly string bannerText = """
         Linkstor80 - The Z80 linker for the 21th century
-        (c) Konamiman 2023
+        (c) Konamiman 2025
 
         """;
 
@@ -58,14 +58,15 @@ internal partial class Program
 
         If the current linking mode is "separate code and data" then the code segment 
         of the file will be linked after the code segment of the last linked file 
-        (unless a different address is supplied beforehand with --code), and the data 
-        segment of the file will be linked after the data segment of the last linked 
-        file (unless a different address is supplied beforehand with --data).
+        (unless a different address is supplied beforehand with --code or --align-code),
+        and the data segment of the file will be linked after the data segment of the last
+        linked file (unless a different address is supplied beforehand with --data
+        or --align-data).
 
         Otherwise, the entire file (data and then code, or the opposite) will be linked 
         after the last linked file (unless a different address is supplied beforehand
-        with --code). It may be a bit confusing but indeed, the entire file is linked 
-        starting at the address specified by --code even in "data before code" mode.
+        with --code or --align-code). It may be a bit confusing but indeed, the entire file
+        is linked starting at the address specified by --code even in "data before code" mode.
 
     -dbc, --data-before-code
         Switches the linking process to "data before code" mode: any relocatable file 
@@ -96,12 +97,24 @@ internal partial class Program
         "separate code and data" mode it's not possible to go back to the "code before data" 
         and "data before code" modes.
 
+    -ac, --align-code <alignment>
+        Specifies the alignment for the address where the linking of the next relocatable file
+        (the whole file or only the code segment, depending on the linking mode) will start:
+        the address will be set the the last address of the previous program plus one, rounded up
+        to the nearest multiple of the specified alignment value.
+
+    -ad, --align-data <alignment>
+        Specifies the alignment for the address in which the data segment of the next
+        relocatable file will be linked: the address will be set to the last data segment
+        address of the previous program plus one, rounded up to the nearest multiple of the
+        specified alignment value. This argument can be used only after the linking process
+        has been set to "separate code and data" mode with the --data argument.
 
     CONFIGURATION FLAGS
 
     -af, --args-file <file path>
         Read additional arguments from the specified file. The arguments are
-        processed immediately. Recursivity is not supported (additional
+        processed immediately. Recursion is not supported (additional
         --args-file arguments aren't allowed inside an arguments file).
         A non-absolute path will be considered relative to the current directory.
         

--- a/LK80/Program.cs
+++ b/LK80/Program.cs
@@ -595,6 +595,28 @@ internal partial class Program
             else if(arg is "-dbc" or "--data-before-code") {
                 linkingSequence.Add(new SetDataBeforeCodeMode());
             }
+            else if(arg is "-ac" or "--align-code") {
+                if(i == args.Length - 1 || args[i + 1][0] == '-') {
+                    return $"The {arg} argument needs to be followed by a value";
+                }
+                else {
+                    i++;
+                    var value = ParseNumericArg(arg, args[i], false, out error);
+                    if(error is not null) return error;
+                    linkingSequence.Add(new AlignCodeSegmentAddress() { Value = value });
+                }
+            }
+            else if(arg is "-ad" or "--align-data") {
+                if(i == args.Length - 1 || args[i + 1][0] == '-') {
+                    return $"The {arg} argument needs to be followed by a value";
+                }
+                else {
+                    i++;
+                    var value = ParseNumericArg(arg, args[i], false, out error);
+                    if(error is not null) return error;
+                    linkingSequence.Add(new AlignDataSegmentAddress() { Value = value });
+                }
+            }
             else if(arg is "-y" or "--symbols-file") {
                 generateListingFile = true;
                 if(i != args.Length - 1 && args[i + 1][0] != '-') {
@@ -830,6 +852,8 @@ internal partial class Program
                     SetCodeSegmentAddress scsa => $"Set code segment address to {scsa.Address:X4}h\r\n",
                     SetDataSegmentAddress sdsa => $"Set data segment address to {sdsa.Address:X4}h\r\n",
                     RelocatableFileReference rfr => $"Process file {rfr.FullName}\r\n",
+                    AlignCodeSegmentAddress acsa => $"Align code segment address to {acsa.Value} bytes\r\n",
+                    AlignDataSegmentAddress adsa => $"Align data segment address to {adsa.Value} bytes\r\n",
                     _ => throw new InvalidOperationException($"Unexpected linking sequence item: {item.GetType().Name}")
                 };
             }

--- a/Linker/AlignCodeSegmentAddress.cs
+++ b/Linker/AlignCodeSegmentAddress.cs
@@ -1,0 +1,10 @@
+﻿namespace Konamiman.Nestor80.Linker;
+
+/// <summary>
+/// Represents an "align code segment address" instruction
+/// to process during the linking process.
+/// </summary>
+public class AlignCodeSegmentAddress : ILinkingSequenceItem
+{
+    public ushort Value { get; set; }
+}

--- a/Linker/AlignDataSegmentAddress.cs
+++ b/Linker/AlignDataSegmentAddress.cs
@@ -1,0 +1,10 @@
+﻿namespace Konamiman.Nestor80.Linker;
+
+/// <summary>
+/// Represents an "align data segment address" instruction
+/// to process during the linking process.
+/// </summary>
+public class AlignDataSegmentAddress : ILinkingSequenceItem
+{
+    public ushort Value { get; set; }
+}

--- a/Linker/RelocatableFilesProcessor.cs
+++ b/Linker/RelocatableFilesProcessor.cs
@@ -173,6 +173,18 @@ public static class RelocatableFilesProcessor
                     AddError("The value for \"align code segment address\" can't be zero");
                 }
                 else {
+                    if(codeSegmentAddressFromInput is null) {
+                        if(programInfos.Count == 0) {
+                            codeSegmentAddressFromInput = DEFAULT_CODE_SEGMENT_START_ADDRESS;
+                        }
+                        else {
+                            var lastProgram = programInfos.Last(pi => pi.HasContent);
+                            codeSegmentAddressFromInput =
+                                segmentsSequencingMode is SegmentsSequencingMode.CombineSameSegment ?
+                                (ushort)(lastProgram.CodeSegmentEnd + 1) :
+                                (ushort)(lastProgram.MaxSegmentEnd + 1);
+                        }
+                    }
                     codeSegmentAddressFromInput ??= (ushort)((programInfos.LastOrDefault(pi => pi.HasContent)?.CodeSegmentEnd ?? DEFAULT_CODE_SEGMENT_START_ADDRESS - 1) + 1);
                     codeSegmentAddressFromInput = Align(codeSegmentAddressFromInput.Value, acsa.Value);
                 }

--- a/Nestor80.sln
+++ b/Nestor80.sln
@@ -21,6 +21,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{F7F80F37-5
 		docs\LanguageReference.md = docs\LanguageReference.md
 		docs\MACRO-80.txt = docs\MACRO-80.txt
 		docs\RelocatableFileFormat.md = docs\RelocatableFileFormat.md
+		docs\WritingRelocatableCode.md = docs\WritingRelocatableCode.md
 		docs\Z280Support.md = docs\Z280Support.md
 	EndProjectSection
 EndProject

--- a/docs/LanguageReference.md
+++ b/docs/LanguageReference.md
@@ -1263,7 +1263,7 @@ Instruction arguments are specified using the standard notation `<argument>`. A 
 💡 If the `--accept-dot-prefix` argument is passed to Nestor80 then it's possible to write all the instructions listed here prefixed with a dot (`.`), except those that have a dot  prefixing its name already. For example ` .ORG` will be accepted as an alias for `ORG`. This may be useful when assembling code written for other assemblers.
 
 
-### .ALIGN
+### .ALIGN 🆕
 
 _Syntax:_ `.ALIGN <alignment>[,<value>]`
 

--- a/docs/LanguageReference.md
+++ b/docs/LanguageReference.md
@@ -1263,6 +1263,45 @@ Instruction arguments are specified using the standard notation `<argument>`. A 
 💡 If the `--accept-dot-prefix` argument is passed to Nestor80 then it's possible to write all the instructions listed here prefixed with a dot (`.`), except those that have a dot  prefixing its name already. For example ` .ORG` will be accepted as an alias for `ORG`. This may be useful when assembling code written for other assemblers.
 
 
+### .ALIGN
+
+_Syntax:_ `.ALIGN <alignment>[,<value>]`
+
+Modifies the current location counter, increasing it (if necessary) to make it a multiple of the `<alignment>` argument. The addresses in between are filled with `<value>` if specified, or with zeros otherwise. `<alignment>` can be any non-zero 16 bit value.
+
+Example:
+
+```
+  org 100h
+
+  defb 1,2,3
+DISALIGNED:
+
+  .align 16
+
+ALIGNED:
+  defb 4,5,6
+```
+
+This is equivalent to:
+
+```
+  org 100h
+
+  defb 1,2,3
+DISALIGNED:
+
+  defs 13
+
+ALIGNED:
+  defb 4,5,6
+```
+
+In both cases `DISALIGNED` will be at address 103h and `ALIGNED` at address 110h, which is the closest multiple of 16 after 103h.
+
+⚠ This instruction can be used only when buidling an absolute file. Address alignments for relocatable files are controlled with the Linkstor80's `--align-code` and `--align-data` arguments (make sure that you are using Linkstor80 v1.1 or newer). See ["Writing relocatable code"](WritingRelocatableCode.md).
+
+
 ### .COMMENT
 
 _Syntax:_ `.COMMENT <delimiter><text><delimiter>`
@@ -1616,45 +1655,6 @@ Disables the [relative labels](#relative-labels-) feature. See also [`.RELAB`](#
 _Syntax:_ `.Z80`
 
 Sets the Z80 as the current target CPU. This instruction is provided for compatibility with MACRO-80, new programs should use [`.CPU Z80`](#cpu-) instead.
-
-
-### ALIGN
-
-_Syntax:_ `ALIGN <alignment>[,<value>]`
-
-Modifies the current location counter, increasing it (if necessary) to make it a multiple of the `<alignment>` argument. The addresses in between are filled with `<value>` if specified, or with zeros otherwise. `<alignment>` can be any non-zero 16 bit value.
-
-Example:
-
-```
-  org 100h
-
-  defb 1,2,3
-DISALIGNED:
-
-  align 16
-
-ALIGNED:
-  defb 4,5,6
-```
-
-This is equivalent to:
-
-```
-  org 100h
-
-  defb 1,2,3
-DISALIGNED:
-
-  defs 13
-
-ALIGNED:
-  defb 4,5,6
-```
-
-In both cases `DISALIGNED` will be at address 103h and `ALIGNED` at address 110h, which is the closest multiple of 16 after 103h.
-
-⚠ This instruction can be used only when buidling an absolute file. Address alignments for relocatable files are controlled with the Linkstor80's `--align-code` and `--align-data` arguments (make sure that you are using Linkstor80 v1.1 or newer). See ["Writing relocatable code"](WritingRelocatableCode.md).
 
 
 ### AREA (.AREA) ®

--- a/docs/LanguageReference.md
+++ b/docs/LanguageReference.md
@@ -1618,6 +1618,45 @@ _Syntax:_ `.Z80`
 Sets the Z80 as the current target CPU. This instruction is provided for compatibility with MACRO-80, new programs should use [`.CPU Z80`](#cpu-) instead.
 
 
+### ALIGN
+
+_Syntax:_ `ALIGN <alignment>[,<value>]`
+
+Modifies the current location counter, increasing it (if necessary) to make it a multiple of the `<alignment>` argument. The addresses in between are filled with `<value>` if specified, or with zeros otherwise. `<alignment>` can be any non-zero 16 bit value.
+
+Example:
+
+```
+  org 100h
+
+  defb 1,2,3
+DISALIGNED:
+
+  align 16
+
+ALIGNED:
+  defb 4,5,6
+```
+
+This is equivalent to:
+
+```
+  org 100h
+
+  defb 1,2,3
+DISALIGNED:
+
+  defs 13
+
+ALIGNED:
+  defb 4,5,6
+```
+
+In both cases `DISALIGNED` will be at address 103h and `ALIGNED` at address 110h, which is the closest multiple of 16 after 103h.
+
+⚠ This instruction can be used only when buidling an absolute file. Address alignments for relocatable files are controlled with the Linkstor80's `--align-code` and `--align-data` arguments (make sure that you are using Linkstor80 v1.1 or newer). See ["Writing relocatable code"](WritingRelocatableCode.md).
+
+
 ### AREA (.AREA) ®
 
 _Syntax:_ `AREA <name> [({ABS|REL}[,{CON|OVR}])]`

--- a/docs/WritingRelocatableCode.md
+++ b/docs/WritingRelocatableCode.md
@@ -441,6 +441,74 @@ Notice how:
 * The fixed address of a common block is right before the data segment of the program in which it first appears.
 
 
+## Aligning code
+
+Sometimes you'll need part of your code or data to be aligned at a given boundary in memory, for example you may want the start of a data table to be located at an address that is a multiple of 256. While you can achieve that by simply using the `ALIGN` instruction in your code when building an absolute file, in the case of relocatable code you'll need to rely on the linker for that.
+
+To that end Linkstor80 provides two arguments:
+
+* `--align-code <alignment>`: Instructs the linker to start the linking of the code segment for the next program (if the "separate code and data" linking mode is active) or the entire next program (if one of the "code before data" or "data before code" modes is active) in the first address that is greater than the last address used by the previous program (the last code segment or data segment address, depending on the linking mode) _and_ is a multiple of the `<alignment>` argument provided.
+
+* `--align-data <alignment>`: This argument can be used only in "separate code and data" mode and is similar to `--align-code`, but it applies to the data segment only.
+
+Let's see an example using the `PROG1.ASM` and `PROG2.ASM` files that we saw in the "Rules for code and data organization in the linked program" section. Assuming you have already assembled them with N80, run the following to link them using the code alignment feature:
+
+```
+LK80 --output-file PROG.BIN --code 0 PROG1.REL --align-code 0020h PROG2.REL
+```
+
+This is how the resulting `PROG.BIN` file will look like (dots represent zero bytes):
+
+```
+0000 ?PROG_1_DATA?!PR
+0010 OG_1_CODE!......
+0020 ?PROG_2_DATA?!PR
+0030 OG_2_CODE!
+```
+
+As you can see the first program contents end at address 0019h, then we instruct the linker to start the next program at the first address after that one that is a multiple of 16. The first address for which that is true is 0020h, so that's where the second program is linked.
+
+Switching to the "code before data" mode has a similar result:
+
+```
+LK80 --output-file PROG.BIN --code-before-data --code 0 \
+     PROG1.REL --align-code 0020h PROG2.REL
+```
+
+Result:
+
+```
+0000 !PROG_1_CODE!?PR
+0010 OG_1_DATA?......
+0020 !PROG_2_CODE!?PR
+0030 OG_2_DATA?
+```
+
+Now let's take a look at what happens when we switch to "separate code and data" mode and use both `--align-code` and `--align-data`:
+
+```
+LK80 --output-file PROG.BIN --code 0 --data 0040h PROG1.REL \
+     --align-code 0010h --align-data 0020h PROG2.REL
+```
+
+Result:
+
+```
+0000 !PROG_1_CODE!...
+0010 !PROG_2_CODE!...
+0020 ................
+0030 ................
+0040 ?PROG_1_DATA?...
+0050 ................
+0060 ?PROG_2_DATA?
+```
+
+We see the two alignments in place here:
+
+* The first program's code ends at address 000Ch, and then we instruct the linker to start linking the next program's code at the next address that is a multiple of 16. That address is 0010h.
+* Similarly, the first program's data ends at address 004Ch, and then we instruct the linker to start linking the next program's data at the next address that is a multiple of 32. That address is 0060h.
+
+
 ## Combining programs into libraries
 
 The Libstor80 tool can be used to combine multiple relocatable files into one single library file, which can then be used with LINK-80 instead of the individual relocatable files.

--- a/docs/WritingRelocatableCode.md
+++ b/docs/WritingRelocatableCode.md
@@ -443,7 +443,7 @@ Notice how:
 
 ## Aligning code
 
-Sometimes you'll need part of your code or data to be aligned at a given boundary in memory, for example you may want the start of a data table to be located at an address that is a multiple of 256. While you can achieve that by simply using the `ALIGN` instruction in your code when building an absolute file, in the case of relocatable code you'll need to rely on the linker for that.
+Sometimes you'll need part of your code or data to be aligned at a given boundary in memory, for example you may want the start of a data table to be located at an address that is a multiple of 256. While you can achieve that by simply using the `.ALIGN` instruction in your code when building an absolute file, in the case of relocatable code you'll need to rely on the linker for that.
 
 To that end Linkstor80 provides two arguments:
 
@@ -507,6 +507,11 @@ We see the two alignments in place here:
 
 * The first program's code ends at address 000Ch, and then we instruct the linker to start linking the next program's code at the next address that is a multiple of 16. That address is 0010h.
 * Similarly, the first program's data ends at address 004Ch, and then we instruct the linker to start linking the next program's data at the next address that is a multiple of 32. That address is 0060h.
+
+Notes:
+
+* The `--align-code` and `--align-data` arguments were introduced in version 1.1 of Linkstor80.
+* By default Linkstor80 will fill gaps between programs with zero bytes, you can use the `--fill` argument to specify a different value.
 
 
 ## Combining programs into libraries


### PR DESCRIPTION
* Add a new `.ALIGN` assembler instruction to be used when building absolute code.
* Add the `--align-code` and `--align-data` to Linkstor80.

See the updated documentation for details.