### PR TITLE
Fix: external symbols declared as root inside modules with a ":" prefix

### DIFF
--- a/Assembler/AssemblySourceProcessor.cs
+++ b/Assembler/AssemblySourceProcessor.cs
@@ -914,9 +914,9 @@ namespace Konamiman.Nestor80.Assembler
                     items.Add(LinkItem.ForAddressReference(ad.Type, ad.Value));
                 }
                 else if(part is SymbolReference sr) {
-                    var symbol = state.GetSymbolWithoutLocalNameReplacement(state.Modularize(sr.SymbolName));
+                    var symbol = state.GetSymbolWithoutLocalNameReplacement(state.Modularize(sr));
                     if(symbol is null) {
-                        throw new InvalidOperationException($"{nameof(GetLinkItemsGroupFromExpression)}: {symbol} doesn't exist (this should have been catched earlier)");
+                        throw new InvalidOperationException($"{nameof(GetLinkItemsGroupFromExpression)}: {state.Modularize(sr)} doesn't exist (this should have been catched earlier)");
                     }
                     if(symbol.IsExternal) {
                         items.Add(LinkItem.ForExternalReference(symbol.EffectiveName));

--- a/Assembler/Infrastructure/AssemblyState.cs
+++ b/Assembler/Infrastructure/AssemblyState.cs
@@ -637,17 +637,22 @@ namespace Konamiman.Nestor80.Assembler.Infrastructure
             }
         }
 
+        public string Modularize(SymbolReference symbolRef, bool isConstantDefinition = false)
+        {
+            return Modularize(symbolRef.SymbolName, isConstantDefinition, symbolRef.IsRoot);
+        }
+
         /// <summary>
         /// Given a symbol name, prefixes it with the current module or non-relative label name
         /// if needed, unless the symbol is declared as root for the current module or is prefixed with ":".
         /// </summary>
         /// <param name="symbol">Symbol to check.</param>
         /// <returns>Symbol (maybe) prefixed with the current module or non-relative label name.</returns>
-        public string Modularize(string symbol, bool isConstantDefinition = false)
+        public string Modularize(string symbol, bool isConstantDefinition = false, bool isRoot = false)
         {
             var inModule = CurrentModule is not null;
 
-            if (inModule && currentRootSymbols.Contains(symbol))
+            if (inModule && (isRoot || currentRootSymbols.Contains(symbol)))
             {
                 return symbol;
             }


### PR DESCRIPTION
It was not possible to declare an external symbol as root inside a module by using the `:` prefix. The following example code would throw an exception:

```
extrn FOOBAR

module FIZZBUZZ

call :FOOBAR

endmod
```
