### PR TITLE
Fix: SDCC build was broken ("Different value in pass 1 and 2" errors)

### DIFF
--- a/Assembler/Infrastructure/AssemblyState.cs
+++ b/Assembler/Infrastructure/AssemblyState.cs
@@ -149,17 +149,18 @@ namespace Konamiman.Nestor80.Assembler.Infrastructure
             lastUsedSdccAreaIndex = -1;
 
             if(isSdccBuild) {
+                SwitchToLocation(0);
                 SetIsSdccBuild();
                 SwitchToSdccArea("_CODE");
             }
             else {
                 SwitchToArea(buildType != BuildType.Absolute ? AddressType.CSEG : AddressType.ASEG);
+                SwitchToLocation(0);
             }
 
             LocationPointersByArea[AddressType.CSEG] = 0;
             LocationPointersByArea[AddressType.DSEG] = 0;
             LocationPointersByArea[AddressType.ASEG] = 0;
-            SwitchToLocation(0);
 
             if(streamCanSeek) {
                 SourceStreamReader.BaseStream.Seek(0, SeekOrigin.Begin);


### PR DESCRIPTION
https://github.com/Konamiman/Nestor80/pull/26, introduced in Nestor80 v1.3.3, introduced a bug that prevented assembling code with SDCC build type (with "different values in pass 1 and pass 2" errors). This pull request fixes that.