### PR TITLE
Fix: "discard hash prefix" option now working when the # was the first character of the expression

### DIFF
--- a/Assembler/Expressions/Expression.cs
+++ b/Assembler/Expressions/Expression.cs
@@ -229,10 +229,6 @@ namespace Konamiman.Nestor80.Assembler
         /// <exception cref="InvalidExpressionException">The supplied string doesn't represent a valid expression</exception>
         public static Expression Parse(string expressionString, bool forDefb = false, bool isByte = false)
         {
-            if(DiscardHashPrefix && expressionString[0] == '#') {
-                expressionString = expressionString[1..];
-            }
-
             if(OutputStringEncoding is null) {
                 throw new InvalidOperationException($"{nameof(Expression)}.{nameof(Parse)}: { nameof(OutputStringEncoding)} is null");
             }
@@ -267,6 +263,10 @@ namespace Konamiman.Nestor80.Assembler
                 IncreaseParsedStringPointer();
 
             var currentChar = parsedString[parsedStringPointer];
+            if(DiscardHashPrefix && currentChar == '#') {
+                IncreaseParsedStringPointer();
+                currentChar = parsedString[parsedStringPointer];
+            }
 
             if(char.IsDigit(currentChar) || currentChar is '#' or '%') {
                 ExtractNumber();


### PR DESCRIPTION
The Nestor80 `--discard-hash-prefix` option was only working when the `#` character was the first character of the expression being evaluated, in other cases (e.g. when the expression started with parenthesis) the hash was not being removed. This pull request fixes that.