### PR TITLE
Fix: "ld (ix+n),n" instructions throwing an exception in SDCC build

### DIFF
--- a/Assembler/AssemblySourceProcessor.cs
+++ b/Assembler/AssemblySourceProcessor.cs
@@ -820,7 +820,7 @@ namespace Konamiman.Nestor80.Assembler
 
                 if(buildType is BuildType.Sdcc) {
                     expressionPendingEvaluation.Expression.ValidateAndPostifixize();
-                    var simplifyOk = expressionPendingEvaluation.Expression.SimplifyForSdcc();
+                    var simplifyOk = referencedSymbolNames.Count() == 0 || expressionPendingEvaluation.Expression.SimplifyForSdcc();
                     if(!simplifyOk) { 
                         AddError(AssemblyErrorCode.ExpressionInvalidForSdcc, $"Invalid expression for {processedLine.Opcode.ToUpper()}: the expression is not supported by the SDCC relocatable file format");
                         continue;


### PR DESCRIPTION
The `ld (ix+n),n` and `ld (iy+n),n` instructions were throwing a "the expression is not supported by the SDCC relocatable file format" exception when assembling them with SDCC build type. This pull request fixes that.