### PR TITLE
Add .GLOBL as a supported alias for EXTRN

### DIFF
--- a/Assembler/AssemblySourceProcessor.PseudoOps.cs
+++ b/Assembler/AssemblySourceProcessor.PseudoOps.cs
@@ -209,10 +209,13 @@ namespace Konamiman.Nestor80.Assembler
             // EXT: Alias for EXTRN
             { "EXT", ProcessExternalDeclarationLine },
 
-            // EXTRN: Alias for EXTRN
+            // EXTERNAL: Alias for EXTRN
             { "EXTERNAL", ProcessExternalDeclarationLine },
 
-            // EXTERNAL <symbol>[,<symbol>[,...]]: Declare symbols as externals
+            // .GLOBL: Alias for EXTRN
+            { ".GLOBL", ProcessExternalDeclarationLine },
+
+            // EXTERN <symbol>[,<symbol>[,...]]: Declare symbols as externals
             { "EXTRN", ProcessExternalDeclarationLine },
 
             // GLOBAL: Alias for PUBLIC

--- a/docs/LanguageReference.md
+++ b/docs/LanguageReference.md
@@ -2172,7 +2172,7 @@ db 2
 ```
 
 
-### EXTRN (EXT, EXTERNAL) ®
+### EXTRN (EXT, EXTERNAL, .GLOBL) ®
 
 _Syntax:_ `EXTRN <symbol>[,<symbol>[,...]]`
 
@@ -2190,6 +2190,8 @@ call FOO
 ```
 
 Additionally, if the `--unknown-symbols-external` argument is passed to Nestor80 then any symbol that is still unknown at the end of pass 2 will be implicitly considered an external symbol.
+
+⚠ Do not confuse `.GLOBL` (alias for `EXTRN`, introduced for compatibility with the sdasz80 assembler) with `GLOBAL` (alias for [`PUBLIC`](#public-entry-global-)).
 
 See also [`PUBLIC`](#public-entry-global-).
 
@@ -2769,7 +2771,9 @@ public FOO
 FOO:
 ```
 
-See also [`EXTRN`](#extrn-ext-external-).
+⚠ Do not confuse `.GLOBL` (alias for [`EXTRN`](#extrn-ext-external-globl-), introduced for compatibility with the sdasz80 assembler) with `GLOBAL` (alias for `PUBLIC`).
+
+See also [`EXTRN`](#extrn-ext-external-globl-).
 
 
 ### REPT


### PR DESCRIPTION
Add `.GLOBL` as a recognized alias for `EXTRN`, for compatibility with the sdasz80 assembler.