### PR TITLE
Add support for the "n(ix|iy)" syntax in indexed instructions

### DIFF
--- a/Assembler/AssemblySourceProcessor.CpuInstructions.cs
+++ b/Assembler/AssemblySourceProcessor.CpuInstructions.cs
@@ -11,13 +11,12 @@ namespace Konamiman.Nestor80.Assembler
 
     public partial class AssemblySourceProcessor
     {
-        private static readonly Regex ixPlusArgumentRegex = new(@"^\(\s*IX\s*[+-].+\)$", RegxOp);
-        private static readonly Regex iyPlusArgumentRegex = new(@"^\(\s*IY\s*[+-].+\)$", RegxOp);
+        private static readonly Regex ixPlusArgumentRegex = new(@"^(\(\s*IX\s*[+-].+\))|(.+\(\s*IX\s*\))$", RegxOp);
+        private static readonly Regex iyPlusArgumentRegex = new(@"^(\(\s*IY\s*[+-].+\))|(.+\(\s*IY\s*\))$", RegxOp);
         private static readonly Regex pcPlusArgumentRegex = new(@"^\(\s*PC\s*[+-].+\)$", RegxOp);
         private static readonly Regex spPlusArgumentRegex = new(@"^\(\s*SP\s*[+-].+\)$", RegxOp);
         private static readonly Regex hlPlusArgumentRegex = new(@"^\(\s*HL\s*[+-].+\)$", RegxOp);
-        private static readonly Regex indexPlusArgumentRegex = new(@"^\(\s*I(X|Y)\s*(?<sign>[+-])(?<expression>.+)\)$", RegxOp);
-        private static readonly Regex registerPlusArgumentRegex = new(@"^\(\s*(IX|IY|PC|SP|HL)\s*(?<sign>[+-])(?<expression>.+)\)$", RegxOp);
+        private static readonly Regex registerPlusArgumentRegex = new(@"^(\(\s*(IX|IY|PC|SP|HL)\s*(?<sign>[+-])(?<expression>.+)\))|((?<sign>[+-])?(?<expression>.+)\s*\(\s*(IX|IY)\s*\))$", RegxOp);
         private static readonly Regex z80MemPointedByRegisterRegex = new(@"^\(\s*(?<reg>HL|DE|BC|IX|IY|SP|C)\s*\)$", RegxOp);
         private static readonly Regex z280MemPointedByRegisterRegex = new(@"^\(\s*(?<reg>HL|DE|BC|IX|IY|PC|SP|C|IX *\+ *IY|HL *\+ *IX|HL *\+ *IY)\s*\)$", RegxOp);
         private static readonly Regex registerRegex = new(@"^[A-Z]{1,3}$", RegxOp);
@@ -551,7 +550,7 @@ namespace Konamiman.Nestor80.Assembler
         private static (string, bool) GetExpressionAndSignFromIndexArgument(string argument)
         {
             var match = registerPlusArgumentRegex.Match(argument);
-            var ixRegisterSign = match.Groups["sign"].Value;
+            var ixRegisterSign = match.Groups["sign"].Success ? match.Groups["sign"].Value : "+";
             var expressionText = ixRegisterSign + match.Groups["expression"].Value;
             return (expressionText, ixRegisterSign == "-");
         }


### PR DESCRIPTION
Add support for the `n(ix)` and `n(iy)` syntax for instructions with index addressing, as equivalent to the standard form `(ix+n)` and `(iy+n)`,  for compatibility with the sdasz80 assembler. Example: `ld a,34(ix)` is equivalent to `ld a,(ix+34)` and `inc -34(iy)` is equivalent to `inc (iy-34)`.