### PR TITLE
Fix ' and " symbols usage as macro arguments

### DIFF
--- a/Assembler/Infrastructure/SourceLineWalker.cs
+++ b/Assembler/Infrastructure/SourceLineWalker.cs
@@ -480,6 +480,11 @@ namespace Konamiman.Nestor80.Assembler.Infrastructure
                     chars.Add(theChar);
                     continue;
                 }
+                else if(nextCharIsLiteral) {
+                    chars.Add(theChar);
+                    nextCharIsLiteral = false;
+                    continue;
+                }
                 else if (theChar == '"' || theChar == '\'')
                 {
                     insideString = true;
@@ -505,13 +510,6 @@ namespace Konamiman.Nestor80.Assembler.Infrastructure
                         chars.Add(theChar);
                         continue;
                     }
-                }
-
-                if (nextCharIsLiteral)
-                {
-                    chars.Add(theChar);
-                    nextCharIsLiteral = false;
-                    continue;
                 }
 
                 if (spaceFoundAfterArg)


### PR DESCRIPTION
When the `'` symbol or the `"` symbol was used as a literal macro argument (so prefixed with `!`), it was mistakenly interpreted as the start of a string instead of the symbol itself.

For example, given this code:

```
    org 100h

TOKEN: macro x,y
    db "&x"+128,y
    endm

    TOKEN	!",1
```

Without this fix it would throw an exception: _"String of 3 bytes found as part of an expression, this should have been filtered out by Expression.Parse"_. With this fix it produces the expected code:

```
                        org 100h
                                
  0100              TOKEN: macro x,y
                        db "&x"+128,y
                        endm
                                
                        TOKEN	!',1
  0100    A7 01         db "'"+128,1
```
