### PR TITLE
Linkstor80: Fix one byte gap between linked programs when a segment is empty

### DIFF
--- a/Linker/ProgramInfo.cs
+++ b/Linker/ProgramInfo.cs
@@ -70,10 +70,23 @@ internal class ProgramInfo
         AbsoluteSegmentRange = HasAbsolute ? new AddressRange(AbsoluteSegmentStart, AbsoluteSegmentEnd, Assembler.AddressType.ASEG) : null;
     }
 
-    public ushort MaxSegmentEnd => 
-        HasAbsolute ? 
-        Math.Max(Math.Max(CodeSegmentEnd, DataSegmentEnd), AbsoluteSegmentEnd) :
-        Math.Max(CodeSegmentEnd, DataSegmentEnd);
+    // The "end" address of an empty segment is set to the segment start address,
+    // which points one byte past the actual end of the program
+    // (it's the address at which the segment would have started);
+    // thus for empty segments the previous address needs to be considered instead.
+    public ushort MaxSegmentEnd
+    {
+        get
+        {
+            var maxEnd = Math.Max(
+                HasCode ? CodeSegmentEnd : CodeSegmentStart - 1,
+                HasData ? DataSegmentEnd : DataSegmentStart - 1);
+            if(HasAbsolute) {
+                maxEnd = Math.Max(maxEnd, AbsoluteSegmentEnd);
+            }
+            return (ushort)Math.Max(maxEnd, 0);
+        }
+    }
 
     public ProgramData ToProgramData(Dictionary<string, ushort> allKnownSymbols)
     {


### PR DESCRIPTION
## The bug

When linking multiple relocatable files, if a program had an empty segment, the next program was placed in memory one byte further than it should, leaving a spurious one byte gap (holding the fill byte) between the two programs in the generated binary.

Concretely, in "code before data" mode (`--code-before-data`), for a first program whose code size is N and that has no data segment:

- The code segment goes from offset 0 to N-1.
- The (empty) data segment start and end addresses are both set to N.
- `ProgramInfo.MaxSegmentEnd` therefore returned N, so the next program's code was placed at N+1 instead of N.

The symmetric case also happened in "data before code" mode (the default) when a program had no code segment.

## Root cause

For a segment with a size of zero, `ProgramInfo` stores the same value in the segment's start and end addresses, and that value points one byte *past* the actual end of the program's content (it's the address at which the segment *would have* started). `MaxSegmentEnd` took those end addresses into account unconditionally, so whenever the empty segment was the "furthest" one, the computed end of the program was off by one; the linker then started the next program at `MaxSegmentEnd + 1`.

## The fix

`ProgramInfo.MaxSegmentEnd` now treats an empty code or data segment as ending at its start address minus one. This removes the phantom byte while preserving the existing behavior of chaining programs one after another, including for programs that only contain an absolute segment (the empty code/data segment addresses still carry the "next free address" forward). The absolute segment end is still taken into account only when the program actually has an absolute segment, as before.

Since data segments are always placed right after any common blocks, an empty data segment's "start minus one" also correctly covers the end of common blocks defined by the program, so no special handling for commons was needed.

## How to test

You'll need the `N80`, `LK80` and optionally `LB80` executables (build with `dotnet build` on the respective project, or use the published binaries built from this branch).

1. Create two code-only source files (no data segment):

   `prog1.asm`:
   ```
   	cseg
   	db 11h,22h,33h,44h
   	end
   ```

   `prog2.asm`:
   ```
   	cseg
   	db 0AAh,0BBh
   	end
   ```

2. Assemble both: `N80 prog1.asm` and `N80 prog2.asm`.

   Optionally, run `LB80 d prog1.REL` to dump the relocatable file and confirm that the program area size is 4 (0004h) and there's no data area size item (this is the precondition that triggered the bug).

3. Link them in "code before data" mode:

   ```
   LK80 -cbd --code 0100h prog1.REL prog2.REL -o result.bin
   ```

4. Open `result.bin` in a hex editor:

   - **Before the fix** (7 bytes): `11 22 33 44 00 AA BB` - note the spurious `00` gap byte between the two programs.
   - **After the fix** (6 bytes): `11 22 33 44 AA BB` - the second program starts immediately after the first one.

5. To check the symmetric "data before code" case, create `prog3.asm` with a data segment and code:

   ```
   	dseg
   	defs 3
   	cseg
   	db 55h,66h
   	end
   ```

   Assemble it and link with `LK80 --code 0100h prog3.REL prog2.REL -o result2.bin` (data before code is the default mode). The output must be 7 bytes: `00 00 00 55 66 AA BB` (3 data bytes, 2 code bytes, then the second program immediately after).
