### PR TITLE
Update version numbers (Linkstor80 to 1.1.1)

### DIFF
--- a/LK80/LK80.csproj
+++ b/LK80/LK80.csproj
@@ -8,7 +8,8 @@
     <RootNamespace>Konamiman.Nestor80.LK80</RootNamespace>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Version>$(VersionPrefix)</Version>
-    <AssemblyVersion>1.1.0</AssemblyVersion>    
+    <AssemblyVersion>1.1.1</AssemblyVersion>
+    <FileVersion>1.1.1</FileVersion>
   </PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/LK80/Program.cs
+++ b/LK80/Program.cs
@@ -62,7 +62,7 @@ internal partial class Program
         }
 
         if(args[0] is "-v" or "--version") {
-            Console.Write(GetProgramVersion());
+            Console.WriteLine(GetProgramVersion());
             return ERR_SUCCESS;
         }
 

--- a/Linker/Linker.csproj
+++ b/Linker/Linker.csproj
@@ -18,9 +18,10 @@
     <Version>1.1.1</Version>
     <AssemblyVersion>1.1.1</AssemblyVersion>
     <FileVersion>1.1.1</FileVersion>
-    <PackageReleaseNotes>Fix one byte gap between linked programs when a segment is empty
+    <PackageReleaseNotes>- Fix one byte gap between linked programs when a segment is empty
+- Fix stray empty line printed when running at verbosity level 0
 
-https://github.com/Konamiman/Nestor80/pull/40</PackageReleaseNotes>
+https://github.com/Konamiman/Nestor80/pulls?q=is%3Apr+milestone%3ALK80-v1.1.1</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/Linker/Linker.csproj
+++ b/Linker/Linker.csproj
@@ -15,12 +15,12 @@
     <RepositoryUrl>https://github.com/Konamiman/Nestor80</RepositoryUrl>
     <PackageTags>Z80;Z280</PackageTags>
     <PackageIcon>LK80_NuGet_logo.png</PackageIcon>
-    <Version>1.1.0</Version>
-    <AssemblyVersion>1.1.0</AssemblyVersion>
-    <FileVersion>1.1.0</FileVersion>
-    <PackageReleaseNotes>Add the --align-code and --align-data arguments
+    <Version>1.1.1</Version>
+    <AssemblyVersion>1.1.1</AssemblyVersion>
+    <FileVersion>1.1.1</FileVersion>
+    <PackageReleaseNotes>Fix one byte gap between linked programs when a segment is empty
 
-https://github.com/Konamiman/Nestor80/pull/23</PackageReleaseNotes>
+https://github.com/Konamiman/Nestor80/pull/40</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 


### PR DESCRIPTION
- Update LK80 version number to 1.1.1
- Update version numbers and release notes for the assembler NuGet package
- Make `LK80 --help` print a newline after the version number