### PR TITLE
Linkstor80: Fix stray empty line printed when running at verbosity level 0

### DIFF
--- a/LK80/Program.cs
+++ b/LK80/Program.cs
@@ -195,15 +195,14 @@ internal partial class Program
             return ERR_LINKING_FATAL;
         }
 
-        WriteLine();
         if(linkingResult.Errors.Length == 0) {
-            PrintProgress("Success!", 1);
+            PrintProgress("\r\nSuccess!", 1);
             PrintProgress($"Output file: {outputFilePath}", 1);
         }
         else {
             try { outputStream.Close(); } catch { }
             try { File.Delete(outputFilePath); } catch { }
-            PrintProgress("No output file generated.", 1);
+            PrintProgress("\r\nNo output file generated.", 1);
             return ERR_LINKING_ERROR;
         }
 


### PR DESCRIPTION
Fixes #39.

## The bug

On a successful run with `--no-show-banner --verbosity 0`, LK80 printed a single empty line to standard output instead of being completely silent like N80 is. This forced users integrating LK80 into build scripts (makefiles, CI logs) to filter out the spurious blank line.

## Root cause

After the linking process finishes, `Main` printed a blank separator line with an unconditional bare `WriteLine()`, intended to separate the per-file "Processing file:" progress lines from the final "Success!" / "No output file generated." message. However, only the messages around it were gated behind verbosity level 1; the separator itself was printed at any verbosity level. With the banner suppressed and verbosity 0, the separator became the only output of the program.

## The fix

The unconditional `WriteLine()` is removed, and the blank separator is now embedded in the verbosity-gated messages themselves: `PrintProgress("\r\nSuccess!", 1)` and `PrintProgress("\r\nNo output file generated.", 1)`. This is the same pattern N80 already uses (e.g. for the "Listing file:" message). At verbosity 0 nothing is printed at all; at verbosity 1 and above the output is unchanged, since the `WriteLine` helper already strips a leading line feed when a blank line was just printed, so no double blank lines can appear.

Note that warnings and errors are still printed at verbosity 0 (to standard error when it's redirected): that's intentional diagnostic output, distinct from the stray blank line on normal execution that this PR fixes.

## How to test

You'll need `N80` and `LK80` built from this branch (`dotnet build LK80/LK80.csproj` also builds the `Linker` dependency).

1. Create a minimal source file `prog.asm`:

   ```
   	cseg
   	db 11h,22h,33h,44h
   	end
   ```

2. Assemble it: `N80 prog.asm`

3. Link it in "quiet" mode and check that the output is completely empty:

   ```
   LK80 --no-show-banner --no-color-output --verbosity 0 --code 0100h -o prog.bin prog.REL | xxd
   ```

   - **Before the fix**: `xxd` shows a single byte, `0a` (the stray line feed).
   - **After the fix**: no output at all (on Windows, use `LK80 ... > out.txt` and check that `out.txt` is 0 bytes).

4. Check that normal output is unchanged at verbosity 1 and above:

   ```
   LK80 --no-show-banner --no-color-output --verbosity 1 --code 0100h -o prog.bin prog.REL
   ```

   must print, exactly as before this change:

   ```
   Processing file: prog.REL

   Success!
   Output file: <full path>/prog.bin
   ```

5. Check the error path (also touched by this change). Link two files that overlap in memory, e.g. the same program twice at the same address:

   ```
   LK80 --no-show-banner --no-color-output --verbosity 1 --code 0100h prog.REL --code 0100h prog.REL -o clash.bin
   ```

must still print the intersection error followed by a blank line and "No output file generated.", with exit code 5. With `--verbosity 0` and standard error discarded (append `2>/dev/null` to the command, or `2>NUL` on Windows), standard output must be empty. Note that redirecting standard error is what routes the error messages away from standard output: LK80 prints errors to the standard error stream only when it detects that the stream is redirected, and mixes them into the normal output otherwise.
