### PR TITLE
Fix NullReferenceException for forward-referenced LOCAL macro symbols in expressions

### DIFF
--- a/Assembler/AssemblySourceProcessor.cs
+++ b/Assembler/AssemblySourceProcessor.cs
@@ -810,7 +810,12 @@ namespace Konamiman.Nestor80.Assembler
 
             foreach(var expressionPendingEvaluation in expressionsPendingEvaluation) {
                 var referencedSymbolNames = expressionPendingEvaluation.Expression.ReferencedSymbols.Select(s => new { s.SymbolName, IsRoot = s.IsRoot || s.IsExternal });
-                var referencedSymbols = referencedSymbolNames.Select(s => state.GetSymbolWithoutLocalNameReplacement(s.IsRoot ? s.SymbolName : state.Modularize(s.SymbolName)));
+                //GetSymbol (as opposed to GetSymbolWithoutLocalNameReplacement) is needed so that
+                //references to LOCAL symbols of the macro being expanded get their converted "..number" names.
+                var referencedSymbols = referencedSymbolNames.Select(s => {
+                    var symbolName = s.IsRoot ? s.SymbolName : state.Modularize(s.SymbolName);
+                    return state.GetSymbol(ref symbolName);
+                });
                 var hasExternalReferences = false;
                 Address expressionValue = null;
 
@@ -914,9 +919,12 @@ namespace Konamiman.Nestor80.Assembler
                     items.Add(LinkItem.ForAddressReference(ad.Type, ad.Value));
                 }
                 else if(part is SymbolReference sr) {
-                    var symbol = state.GetSymbolWithoutLocalNameReplacement(state.Modularize(sr));
+                    //GetSymbol (as opposed to GetSymbolWithoutLocalNameReplacement) is needed so that
+                    //references to LOCAL symbols of the macro being expanded get their converted "..number" names.
+                    var symbolName = state.Modularize(sr);
+                    var symbol = state.GetSymbol(ref symbolName);
                     if(symbol is null) {
-                        throw new InvalidOperationException($"{nameof(GetLinkItemsGroupFromExpression)}: {state.Modularize(sr)} doesn't exist (this should have been catched earlier)");
+                        throw new InvalidOperationException($"{nameof(GetLinkItemsGroupFromExpression)}: {symbolName} doesn't exist (this should have been catched earlier)");
                     }
                     if(symbol.IsExternal) {
                         items.Add(LinkItem.ForExternalReference(symbol.EffectiveName));

--- a/AssemblerTests/MacroLocalForwardReferencesTests.cs
+++ b/AssemblerTests/MacroLocalForwardReferencesTests.cs
@@ -41,13 +41,22 @@ ME:
             Assert.IsTrue(localLabels.All(s => s.ValueArea == AddressType.CSEG));
 
             //The DEFB ME-MS lines must have been converted to link items groups
-            //(a relocatable difference stored as a byte is resolved at linking time)
+            //(a relocatable difference stored as a byte is resolved at linking time),
+            //each referencing the ME and MS addresses of its own expansion
             var expansionLines = result.ProcessedLines.OfType<MacroExpansionLine>().ToArray();
             Assert.AreEqual(2, expansionLines.Length);
-            foreach(var expansionLine in expansionLines) {
-                var defbLine = expansionLine.Lines.OfType<DefbLine>().First();
+            for(int i = 0; i < expansionLines.Length; i++) {
+                var expansionBase = (ushort)(i * 4);
+                var defbLine = expansionLines[i].Lines.OfType<DefbLine>().First();
                 var linkItemsGroup = defbLine.RelocatableParts.OfType<LinkItemsGroup>().Single();
                 Assert.AreEqual(3, linkItemsGroup.LinkItems.Length);
+
+                //ME-MS in postfix order: address of ME, address of MS, minus operator
+                Assert.IsTrue(linkItemsGroup.LinkItems[0].IsAddressReference);
+                Assert.AreEqual((AddressType.CSEG, (ushort)(expansionBase + 4)), linkItemsGroup.LinkItems[0].GetReferencedAddress());
+                Assert.IsTrue(linkItemsGroup.LinkItems[1].IsAddressReference);
+                Assert.AreEqual((AddressType.CSEG, (ushort)(expansionBase + 1)), linkItemsGroup.LinkItems[1].GetReferencedAddress());
+                Assert.AreEqual(ArithmeticOperatorCode.Minus, linkItemsGroup.LinkItems[2].ArithmeticOperator);
             }
         }
 

--- a/AssemblerTests/MacroLocalForwardReferencesTests.cs
+++ b/AssemblerTests/MacroLocalForwardReferencesTests.cs
@@ -1,0 +1,69 @@
+using Konamiman.Nestor80.Assembler;
+using Konamiman.Nestor80.Assembler.Output;
+using Konamiman.Nestor80.Assembler.Relocatable;
+using NUnit.Framework;
+
+namespace Konamiman.Nestor80.AssemblerTests
+{
+    /// <summary>
+    /// Tests for expressions that make forward references to LOCAL symbols of a macro,
+    /// e.g. the classic M80 "length-prefixed string" idiom:
+    /// the length byte (ME-MS) is emitted before the MS and ME labels are defined.
+    /// </summary>
+    [TestFixture]
+    public class MacroLocalForwardReferencesTests
+    {
+        const string source = @"	.z80
+LENPFX	MACRO
+	LOCAL	MS,ME
+	DEFB	ME-MS
+MS:	DEFB	1,2,3
+ME:
+	ENDM
+
+	LENPFX
+	LENPFX
+	end
+";
+
+        [Test]
+        public void TestForwardReferencedLocalSymbolsInRelocatableByteExpression()
+        {
+            var result = AssemblySourceProcessor.Assemble(source, new AssemblyConfiguration() { BuildType = BuildType.Relocatable });
+
+            Assert.IsFalse(result.HasErrors, string.Join("\r\n", result.Errors.Select(e => e.Message)));
+
+            //Each LOCAL symbol must have been registered with a unique generated
+            //"..number" name and with the address it has in its own expansion
+            var localLabels = result.Symbols.Where(s => s.Name.StartsWith("..")).ToArray();
+            Assert.AreEqual(4, localLabels.Length);
+            CollectionAssert.AreEquivalent(new ushort[] { 1, 4, 5, 8 }, localLabels.Select(s => s.Value).ToArray());
+            Assert.IsTrue(localLabels.All(s => s.ValueArea == AddressType.CSEG));
+
+            //The DEFB ME-MS lines must have been converted to link items groups
+            //(a relocatable difference stored as a byte is resolved at linking time)
+            var expansionLines = result.ProcessedLines.OfType<MacroExpansionLine>().ToArray();
+            Assert.AreEqual(2, expansionLines.Length);
+            foreach(var expansionLine in expansionLines) {
+                var defbLine = expansionLine.Lines.OfType<DefbLine>().First();
+                var linkItemsGroup = defbLine.RelocatableParts.OfType<LinkItemsGroup>().Single();
+                Assert.AreEqual(3, linkItemsGroup.LinkItems.Length);
+            }
+        }
+
+        [Test]
+        public void TestForwardReferencedLocalSymbolsInAbsoluteByteExpression()
+        {
+            var result = AssemblySourceProcessor.Assemble(source, new AssemblyConfiguration() { BuildType = BuildType.Absolute });
+
+            Assert.IsFalse(result.HasErrors, string.Join("\r\n", result.Errors.Select(e => e.Message)));
+
+            var expansionLines = result.ProcessedLines.OfType<MacroExpansionLine>().ToArray();
+            Assert.AreEqual(2, expansionLines.Length);
+            foreach(var expansionLine in expansionLines) {
+                var outputBytes = expansionLine.Lines.OfType<IProducesOutput>().SelectMany(l => l.OutputBytes).ToArray();
+                Assert.AreEqual(new byte[] { 3, 1, 2, 3 }, outputBytes);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a fatal crash (`FATAL: Unexpected error: (NullReferenceException)`) that occurred when a macro expression made a forward reference to LOCAL symbols, as in the classic M80 length-prefixed-string idiom:

```asm
	.z80
LENPFX	MACRO
	LOCAL	MS,ME
	DEFB	ME-MS
MS:	DEFB	1,2,3
ME:
	ENDM

	LENPFX
	end
```

Before this fix:

```
$ N80 bug1a.mac bug1a.rel --build-type rel
FATAL: <LENPFX:2> in line 9: Unexpected error: (NullReferenceException) Object reference not set to an instance of an object.
Assembly failed with 1 fatal
```

This idiom is how MACRO-80 sources typically build tables of length-prefixed strings (e.g. the command name table in the COMMAND2.COM 2.31 sources), so the crash blocked porting such code to Nestor80.

## Root cause

LOCAL macro symbols are stored in the symbol table under generated `..NNNN` names; symbol lookups normally go through `AssemblyState.GetSymbol`, which applies that name conversion while a named macro expansion is active.

However, `DEFB ME-MS` in a relocatable build is a difference of two relocatable addresses stored as a byte, so even in pass 2 it cannot be evaluated inline and is registered as an "expression pending evaluation". The stored `Expression` keeps the original symbol names (`ME`, `MS`). When `ProcessExpressionsPendingEvaluation` later resolved those references it used `GetSymbolWithoutLocalNameReplacement`, which found no symbol named `ME`, returned `null`, and the following `.Any(s => s.IsExternal)` dereferenced it and crashed. Had it survived that point, `GetLinkItemsGroupFromExpression` would have hit the same unconverted-name lookup and thrown too.

## The fix

`Assembler/AssemblySourceProcessor.cs`, two call sites:

- `ProcessExpressionsPendingEvaluation`: resolve each referenced symbol with `state.GetSymbol(ref name)` (the replacement-aware lookup) instead of `GetSymbolWithoutLocalNameReplacement`.
- `GetLinkItemsGroupFromExpression`: same change when converting `SymbolReference` parts to link items.

This is safe because pending expressions are processed immediately after their source line, while the macro expansion state (and its cached local-name conversions) is still active, and the conversions are deterministic across passes. The symbol names inside the `Expression` object are deliberately **not** rewritten: expressions are cached by source text and shared across macro invocations, so mutating one would corrupt subsequent expansions.

## Tests

New regression test file `AssemblerTests/MacroLocalForwardReferencesTests.cs`:

- **Relocatable build**: asserts the source assembles without errors, that each LOCAL symbol gets a unique generated `..NNNN` name with the correct per-invocation address (1, 4, 5, 8 for two invocations), and that each `DEFB ME-MS` line produces a link items group referencing the ME and MS addresses of its own expansion (4 and 1 for the first, 8 and 5 for the second) joined by the minus operator, resolved at link time.
- **Absolute build**: asserts each expansion outputs exactly `03 01 02 03`.

## Testing instructions

Build and run the test suite:

```
dotnet build N80/N80.csproj
dotnet build LK80/LK80.csproj
dotnet test AssemblerTests
```

(On machines without the .NET 6 runtime but with a newer one installed, prefix the `dotnet test` and `dotnet <dll>` commands below with `DOTNET_ROLL_FORWARD=LatestMajor`.)

Reproduce the original crash scenario - save the snippet from the Summary section as `bug1a.mac`, then:

```
dotnet N80/bin/Debug/net6.0/N80.dll bug1a.mac bug1a.rel --build-type rel
dotnet LK80/bin/Debug/net6.0/LK80.dll --output-file bug1a.bin bug1a.rel
xxd bug1a.bin
```

Expected: assembly and linking succeed, and the output is `03 01 02 03` (length byte `ME-MS` = 3, followed by the three data bytes). Before the fix, the N80 step crashed with the NullReferenceException shown above.

Additional scenarios verified manually (all assemble, link, and produce byte-exact correct output):

- Multiple invocations of the same macro, each getting its own unique local labels:

  ```asm
  CMD	MACRO	TEXT
  	LOCAL	MS,ME
  	DEFB	ME-MS
  MS:	DEFB	'&TEXT'
  ME:
  	ENDM

  	CMD	DIR
  	CMD	COPY
  	CMD	TYPE
  ```

  Links to `03 "DIR" 04 "COPY" 04 "TYPE"`.

- Locals mixed with external references (`DEFW EXTSYM+ME-MS`) and used as CPU instruction operands (`JR ME`, `LD DE,MS`), in `--link-80-compatibility` mode: each `LD DE,MS` resolves to its own invocation's `MS` address after linking.
- Nested macros with LOCALs in both the outer and inner macro.
- Absolute builds (`--build-type abs`) of the same idiom.
- The idiom used both inside and outside a `MODULE` block.
