### PR TITLE
Fix silent data loss for characters 80h-9Fh in DEFB strings

### DIFF
--- a/Assembler/AssemblySourceProcessor.cs
+++ b/Assembler/AssemblySourceProcessor.cs
@@ -465,8 +465,8 @@ namespace Konamiman.Nestor80.Assembler
                 }
             }
 
-            if(line.Any(ch => char.IsControl(ch) && ch != '\t')) {
-                line = new string(line.Where(ch => ch == '\t' || !char.IsControl(ch)).ToArray());
+            if(line.Any(ch => ch < ' ' && ch != '\t')) {
+                line = new string(line.Where(ch => ch == '\t' || ch >= ' ').ToArray());
             }
 
             if(state.InsideMultiLineComment) {

--- a/AssemblerTests/AssemblySourceProcessorTests.cs
+++ b/AssemblerTests/AssemblySourceProcessorTests.cs
@@ -9,12 +9,13 @@ namespace Konamiman.Nestor80.AssemblerTests
     public class AssemblySourceProcessorTests
     {
         [Test]
-        // Source bytes in the 80h-9Fh range decode to C1 control characters with ISO 8859-1;
-        // they must be kept in string literals so that the byte values round trip to the output.
-        public void CharsAbove7FhInStringsSurviveByteRoundTrip()
+        // Source byte 7Fh decodes to DEL and bytes in the 80h-9Fh range decode to C1 control
+        // characters with ISO 8859-1; they must be kept in string literals so that the byte
+        // values round trip to the output.
+        public void DelAndC1CharsInStringsSurviveByteRoundTrip()
         {
             var encoding = Encoding.GetEncoding(28591);
-            var sourceBytes = encoding.GetBytes("\torg 100h\r\n\tdefb \"a\u0083b\"\r\n\tend\r\n");
+            var sourceBytes = encoding.GetBytes("\torg 100h\r\n\tdefb \"a\u0083b\u007fc\"\r\n\tend\r\n");
 
             var result = AssemblySourceProcessor.Assemble(
                 new MemoryStream(sourceBytes),
@@ -25,7 +26,7 @@ namespace Konamiman.Nestor80.AssemblerTests
 
             var outputStream = new MemoryStream();
             OutputGenerator.GenerateAbsolute(result, outputStream);
-            CollectionAssert.AreEqual(new byte[] { 0x61, 0x83, 0x62 }, outputStream.ToArray());
+            CollectionAssert.AreEqual(new byte[] { 0x61, 0x83, 0x62, 0x7F, 0x63 }, outputStream.ToArray());
         }
 
         [Test]

--- a/AssemblerTests/AssemblySourceProcessorTests.cs
+++ b/AssemblerTests/AssemblySourceProcessorTests.cs
@@ -1,0 +1,63 @@
+using System.Text;
+using Konamiman.Nestor80.Assembler;
+using Konamiman.Nestor80.Assembler.Errors;
+using NUnit.Framework;
+
+namespace Konamiman.Nestor80.AssemblerTests
+{
+    [TestFixture]
+    public class AssemblySourceProcessorTests
+    {
+        [Test]
+        // Source bytes in the 80h-9Fh range decode to C1 control characters with ISO 8859-1;
+        // they must be kept in string literals so that the byte values round trip to the output.
+        public void CharsAbove7FhInStringsSurviveByteRoundTrip()
+        {
+            var encoding = Encoding.GetEncoding(28591);
+            var sourceBytes = encoding.GetBytes("\torg 100h\r\n\tdefb \"a\u0083b\"\r\n\tend\r\n");
+
+            var result = AssemblySourceProcessor.Assemble(
+                new MemoryStream(sourceBytes),
+                encoding,
+                new AssemblyConfiguration() { BuildType = BuildType.Absolute, OutputStringEncoding = "28591" });
+
+            Assert.IsFalse(result.HasErrors);
+
+            var outputStream = new MemoryStream();
+            OutputGenerator.GenerateAbsolute(result, outputStream);
+            CollectionAssert.AreEqual(new byte[] { 0x61, 0x83, 0x62 }, outputStream.ToArray());
+        }
+
+        [Test]
+        public void CharsNotSupportedByStringEncodingProduceAnError()
+        {
+            var encoding = Encoding.GetEncoding(28591);
+            var sourceBytes = encoding.GetBytes("\torg 100h\r\n\tdefb \"a\u0083b\"\r\n\tend\r\n");
+
+            var result = AssemblySourceProcessor.Assemble(
+                new MemoryStream(sourceBytes),
+                encoding,
+                new AssemblyConfiguration() { BuildType = BuildType.Absolute, OutputStringEncoding = "ASCII" });
+
+            Assert.IsTrue(result.Errors.Any(e => e.Code is AssemblyErrorCode.InvalidExpression && e.Message.Contains("aren't supported by the current encoding")));
+        }
+
+        [Test]
+        public void ControlCharsBelow20hAreRemovedFromSourceLines()
+        {
+            var encoding = Encoding.GetEncoding(28591);
+            var sourceBytes = encoding.GetBytes("\torg 100h\r\n\tdefb 1\u001a\r\n\tend\r\n");
+
+            var result = AssemblySourceProcessor.Assemble(
+                new MemoryStream(sourceBytes),
+                encoding,
+                new AssemblyConfiguration() { BuildType = BuildType.Absolute });
+
+            Assert.IsFalse(result.HasErrors);
+
+            var outputStream = new MemoryStream();
+            OutputGenerator.GenerateAbsolute(result, outputStream);
+            CollectionAssert.AreEqual(new byte[] { 0x01 }, outputStream.ToArray());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Source bytes in the 80h–9Fh range were silently removed from string literals when the input encoding decoded them to C1 control characters (U+0080–U+009F). With `--input-encoding 28591 --string-encoding 28591` (ISO 8859-1, a byte-preserving round trip for legacy 8-bit files), a `DEFB "a«83h»b"` line produced only 2 bytes of output instead of 3 — with no error or warning. In practice this made Shift-JIS message files lose every double-byte lead byte in the 81h–9Fh range.

## Root cause

`ProcessSourceLine` stripped every `char.IsControl` character (except tab) from each source line *before* any parsing. `char.IsControl` is true not only for C0 controls (00h–1Fh) but also for DEL (7Fh) and the C1 range (U+0080–U+009F), which is exactly what single-byte encodings such as ISO 8859-1 decode bytes 80h–9Fh into. The affected characters therefore never reached the string parser, so the existing "string contains characters that aren't supported by the current encoding" error never had a chance to fire — and no error was warranted anyway, since ISO 8859-1 can represent them just fine.

The stripping was introduced to tolerate stray control characters (e.g. ^Z EOF markers) in legacy source files; catching the C1 range was collateral damage.

## The fix

The pre-parse filter now removes only characters below 20h (still keeping tab). Characters in the C1 range and DEL survive into string literals, where the string encoding machinery handles them correctly:

- If the active string encoding can represent them (e.g. 28591), the original byte values round-trip to the output.
- If it can't (e.g. the default us-ascii), the existing regular error "string contains characters that aren't supported by the current encoding" is raised and no output file is generated.

Stray C0 control characters (including ^Z) are still removed as before, so legacy files keep assembling.

## Behavior changes

- Bytes that decode to C1 characters (and DEL, 7Fh) are no longer removed from source lines. Inside strings they now produce output bytes (or an error if unrepresentable); outside strings they will typically produce a syntax error instead of being silently ignored.
- Raw C0 bytes (00h–1Fh) inside string literals are still silently stripped — the filter runs before the parser knows what's a string. Emitting a warning when stripping actually removes something is a possible follow-up.

## Testing instructions

### Automated tests

```
dotnet test AssemblerTests
```

Three new tests in `AssemblerTests/AssemblySourceProcessorTests.cs` cover the byte round trip (for both DEL, 7Fh, and the C1 range), the unsupported-encoding error, and the C0 stripping. All pre-existing tests still pass (475 total).

### Manual verification

Create a test file containing the raw byte 83h inside a string (the `\203` octal escape emits it):

```
printf '\torg\t100h\n\tDEFB\t"a\203b"\n\tend\n' > bug3.mac
```

**1. Byte-preserving round trip:**

```
N80 bug3.mac bug3.bin --build-type abs --input-encoding 28591 --string-encoding 28591
xxd bug3.bin
```

Expected: `61 83 62` (3 bytes). Before the fix: `61 62` (2 bytes, no diagnostic).

**2. Unrepresentable character with the default us-ascii string encoding:**

```
N80 bug3.mac bug3.bin --build-type abs --input-encoding 28591
```

Expected: `ERROR: in line 3: Invalid expression for DEFB: string contains characters that aren't supported by the current encoding (us-ascii)` and no output file. Before the fix: silent 2-byte output.

**3. Legacy files with stray C0 control characters still assemble:**

```
printf '\n\torg\t100h\n\tDEFB\t1\n\tend\n\032' > legacy.mac
N80 legacy.mac legacy.bin --build-type abs
```

Expected: assembles without errors, 1-byte output (the trailing ^Z is ignored as before).
