### PR TITLE
Fix "Unterminated macro" error for a label on the same line as ENDM

### DIFF
--- a/Assembler/AssemblySourceProcessor.cs
+++ b/Assembler/AssemblySourceProcessor.cs
@@ -523,9 +523,32 @@ namespace Konamiman.Nestor80.Assembler
 
             if(definingMacro) {
                 opcode = MaybeResolveDottedAlias(symbol);
-                
+
+                //A label field is allowed before any statement, so when the line starts with a label
+                //it's the next symbol that must be checked for the instructions that affect
+                //the definition state (e.g. "FOO: ENDM" terminates the macro just like a plain "ENDM").
+                string labelBeforeOpcode = null;
+                if(symbol.EndsWith(':') && IsValidSymbolName(symbol) && !walker.AtEndOfLine) {
+                    walker.BackupPointer();
+                    var symbolAfterLabel = MaybeResolveDottedAlias(walker.ExtractSymbol());
+                    if(string.Equals(symbolAfterLabel, "ENDM", StringComparison.OrdinalIgnoreCase) ||
+                        macroDefinitionOrExpansionInstructions.Contains(symbolAfterLabel, StringComparer.OrdinalIgnoreCase)) {
+                        labelBeforeOpcode = symbol;
+                        opcode = symbolAfterLabel;
+                    }
+                    else {
+                        walker.RestorePointer();
+                    }
+                }
+
                 var stillInMacroDefinitionMode = true;
                 if(string.Equals(opcode, "ENDM", StringComparison.InvariantCultureIgnoreCase)) {
+                    //The label is part of the macro body (it will be defined when the macro is expanded),
+                    //so it must be registered before the ENDM gets the chance to finish the definition.
+                    if(labelBeforeOpcode is not null && MacroDefinitionState.Depth == 1) {
+                        AssemblyState.RegisterMacroDefinitionLine(labelBeforeOpcode, false);
+                    }
+
                     processedLine = ProcessEndmLine(opcode, walker);
 
                     //We need to check if we are still in macro definition mode

--- a/AssemblerTests/MacroDefinitionTests.cs
+++ b/AssemblerTests/MacroDefinitionTests.cs
@@ -1,0 +1,87 @@
+using Konamiman.Nestor80.Assembler;
+using NUnit.Framework;
+
+namespace Konamiman.Nestor80.AssemblerTests
+{
+    [TestFixture]
+    public class MacroDefinitionTests
+    {
+        private static byte[] AssembleAbsolute(string source)
+        {
+            var result = AssemblySourceProcessor.Assemble(source, new AssemblyConfiguration() { BuildType = BuildType.Absolute });
+            Assert.IsFalse(result.HasErrors, string.Join("; ", result.Errors.Select(e => e.Message)));
+
+            var outputStream = new MemoryStream();
+            OutputGenerator.GenerateAbsolute(result, outputStream);
+            return outputStream.ToArray();
+        }
+
+        [Test]
+        // The label goes to the macro body, so it's defined at each expansion
+        // pointing to the address that follows the expanded bytes.
+        public void LabelOnSameLineAsEndmTerminatesNamedMacroDefinition()
+        {
+            var bytes = AssembleAbsolute(
+                "\torg 100h\r\n" +
+                "M\tmacro\r\n" +
+                "MS:\tdefb 1,2,3\r\n" +
+                "ME:\tendm\r\n" +
+                "\tM\r\n" +
+                "\tdefb ME-MS\r\n" +
+                "\tend\r\n");
+
+            CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 3 }, bytes);
+        }
+
+        [Test]
+        public void LabelOnSameLineAsEndmTerminatesReptDefinition()
+        {
+            var bytes = AssembleAbsolute(
+                "\torg 100h\r\n" +
+                "\trept 1\r\n" +
+                "\tdefb 7\r\n" +
+                "ME:\tendm\r\n" +
+                "\tdefb ME-100h\r\n" +
+                "\tend\r\n");
+
+            CollectionAssert.AreEqual(new byte[] { 7, 1 }, bytes);
+        }
+
+        [Test]
+        // The "XX: endm" line closes the nested REPT, not the macro being defined,
+        // so the entire line must be stored as part of the macro body.
+        public void LabelOnEndmOfNestedReptStaysInMacroBody()
+        {
+            var bytes = AssembleAbsolute(
+                "\torg 100h\r\n" +
+                "M\tmacro\r\n" +
+                "\trept 1\r\n" +
+                "\tdefb 9\r\n" +
+                "XX:\tendm\r\n" +
+                "\tdefb XX-100h\r\n" +
+                "\tendm\r\n" +
+                "\tM\r\n" +
+                "\tend\r\n");
+
+            CollectionAssert.AreEqual(new byte[] { 9, 1 }, bytes);
+        }
+
+        [Test]
+        // A label before REPT must not prevent the nesting depth increase,
+        // otherwise the ENDM of the nested block would terminate the macro definition.
+        public void LabeledReptInsideMacroDefinitionTracksNestingDepth()
+        {
+            var bytes = AssembleAbsolute(
+                "\torg 100h\r\n" +
+                "M\tmacro\r\n" +
+                "FOO:\trept 2\r\n" +
+                "\tdefb 9\r\n" +
+                "\tendm\r\n" +
+                "\tendm\r\n" +
+                "\tM\r\n" +
+                "\tend\r\n");
+
+            CollectionAssert.AreEqual(new byte[] { 9, 9 }, bytes);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A label field on the same line as `ENDM` prevented the `ENDM` from being recognized while a macro was being defined:

```asm
M	MACRO
	DEFB	1
ME:	ENDM
```

This produced `ERROR: Unterminated macro` (pointing at the `END` line, not at the offending one) plus `WARN: No END statement found`. MACRO-80 allows a label field before any statement, including `ENDM` — it's a natural companion of the classic length-prefixed-string idiom (`DEFB ME-MS` / `MS: DEFB ...` / `ME: ENDM`).

## Root cause

During macro definition mode, `ProcessSourceLine` checked only the *first* symbol of each line for `ENDM`. For `ME:	ENDM` the first symbol is `ME:`, so the whole line was stored as a macro body line and the definition never terminated.

The same first-symbol-only scan also failed to increase the block nesting depth for a labeled `REPT`/`IRP`/`IRPC`/`IRPS` inside a macro definition (e.g. `FOO:	REPT 2`), which made the nested block's `ENDM` terminate the outer macro definition early.

## The fix

When a line inside a macro definition starts with a valid label field, the scanner now peeks at the next symbol to detect the instructions that affect the definition state:

- A terminating `ENDM` after a label registers the label as the last line of the macro body *before* closing the definition. The label is therefore defined on each expansion, pointing just past the expanded bytes - matching M80 semantics and what the length-prefix idiom needs.
- A labeled `ENDM` that closes a *nested* block (depth > 1) keeps the entire line in the macro body, so it is handled again correctly when the body is expanded.
- A labeled `REPT`/`IRP`/`IRPC`/`IRPS` now increases the nesting depth just like the unlabeled form.

Lines outside macro definitions are unaffected; a stray labeled `ENDM` at the top level still produces the usual "ENDM found outside of a macro" error.

## Testing instructions

### Automated tests

```
dotnet test AssemblerTests
```

Four new tests in `AssemblerTests/MacroDefinitionTests.cs` cover: labeled `ENDM` terminating a named macro (and the label's expansion-time address via `ME-MS`), labeled `ENDM` terminating a top-level `REPT`, labeled `ENDM` closing a nested `REPT` inside a macro body, and depth tracking for a labeled `REPT` inside a macro definition. All pre-existing tests still pass (476 total).

### Manual verification

**1. The reported case:**

Create a `bug4.mac` file with:

```
M	MACRO
	DEFB	1
ME:	ENDM

	M
	end
```

Assemble it with:

```
N80 bug4.mac bug4.rel --build-type rel
```

Expected: assembles without errors. Before the fix: `ERROR: in line 8: Unterminated macro` and `WARN: No END statement found`.

**2. Label address semantics (length-prefix idiom):**

Create a `bug4.mac` file with:

```
	org	100h
M	MACRO
MS:	DEFB	1,2,3
ME:	ENDM

	M
	DEFB	ME-MS
	end
```

Then run:

```
N80 bug4b.mac bug4b.bin --build-type abs
xxd bug4b.bin
```

Expected: `01 02 03 03` - `ME` is defined at expansion time, right after the emitted bytes, so `ME-MS` is 3.

**3. Labeled REPT inside a macro definition (nesting depth):**

Create a `bug4c.mac` file with:

```
	org	100h
M	MACRO
FOO:	REPT	2
	DEFB	9
	ENDM
	ENDM

	M
	end
```

Then run:

```
N80 bug4c.mac bug4c.bin --build-type abs
xxd bug4c.bin
```

Expected: `09 09`, no errors. Before the fix, the first `ENDM` terminated the macro definition early and the source failed to assemble.
