### PR TITLE
Update version numbers (N80 to 1.3.6) and release notes for NuGet

### DIFF
--- a/Assembler/Assembler.csproj
+++ b/Assembler/Assembler.csproj
@@ -5,25 +5,28 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <RootNamespace>Konamiman.Nestor80.Assembler</RootNamespace>
-    <AssemblyVersion>1.3.5</AssemblyVersion>
-    <FileVersion>1.3.5</FileVersion>
-    <Version>1.3.5</Version>
+    <AssemblyVersion>1.3.6</AssemblyVersion>
+    <FileVersion>1.3.6</FileVersion>
+    <Version>1.3.6</Version>
     <PackageId>Nestor80</PackageId>
     <Title>Nestor80 assembler library</Title>
     <Authors>Konamiman</Authors>
     <Company />
     <Product>Nestor80 assembler library</Product>
     <PackageTags>Z80;Z280</PackageTags>
-    <Copyright>(c) 2025 Konamiman</Copyright>
+    <Copyright>(c) 2026 Konamiman</Copyright>
     <Description>Z80, R800 and Z280 assembler almost fully compatible with Microsoft Macro80 at the source code level. Produces absolute and relocatable binary files. Relocatable files can be linked using Linkstor80.</Description>
     <PackageProjectUrl></PackageProjectUrl>
     <RepositoryUrl>https://github.com/Konamiman/Nestor80</RepositoryUrl>
     <PackageIcon>N80_NuGet_logo.png</PackageIcon>
     <PackageReadmeFile></PackageReadmeFile>
-    <PackageReleaseNotes>- Fix: ' and " interpreted as string starters when used as arguments for macros
-- Fix: DEFS inside macros not included in listings
+    <PackageReleaseNotes>- Fix spurious warning for a comment after IRPC arguments
+- Fix "Unterminated macro" error for a label on the same line as ENDM
+- Fix silent data loss for characters 80h-9Fh in DEFB strings
+- Fix: user-defined symbols named after operators silently miscompiled or failed
+- Fix NullReferenceException for forward-referenced LOCAL macro symbols in expressions
 
-https://github.com/Konamiman/Nestor80/pulls?q=is%3Apr+milestone%3Av1.3.5</PackageReleaseNotes>
+https://github.com/Konamiman/Nestor80/pulls?q=is%3Apr+milestone%3AN80-v1.3.6</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/N80/N80.csproj
+++ b/N80/N80.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Konamiman.Nestor80.N80</RootNamespace>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Version>$(VersionPrefix)</Version>
-    <AssemblyVersion>1.3.5</AssemblyVersion>
+    <AssemblyVersion>1.3.6</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/N80/Program.Help.cs
+++ b/N80/Program.Help.cs
@@ -5,8 +5,8 @@ namespace Konamiman.Nestor80.N80
     internal partial class Program
     {
         static readonly string bannerText = """
-            Nestor80 - The Z80 and Z280 assembler for the 21th century
-            (c) Konamiman 2025
+            Nestor80 - The Z80 and Z280 assembler for the 21st century
+            (c) Konamiman 2026
 
             """;
 

--- a/N80/Program.cs
+++ b/N80/Program.cs
@@ -116,7 +116,7 @@ namespace Konamiman.Nestor80.N80
             }
 
             if(args[0] is "-v" or "--version") {
-                Console.Write(GetProgramVersion());
+                Console.WriteLine(GetProgramVersion());
                 return ERR_SUCCESS;
             }
 


### PR DESCRIPTION
* Update N80 version number to 1.3.6
* Update version numbers and release notes for the assembler NuGet package
* Also make 'N80 --help' print a newline after the version number
